### PR TITLE
S02: Enemy additional income based on villages

### DIFF
--- a/scenarios/02_The_Raid.cfg
+++ b/scenarios/02_The_Raid.cfg
@@ -114,8 +114,8 @@ Call the Hunt."
         controller=ai
         defeat_condition=no_units_left
         recruit=Goblin Spearman, Orcish Archer, Orcish Assassin, Orcish Grunt, Wolf Rider
-        {GOLD 90 120 150}
-        {INCOME 5 10 15}
+        {GOLD 60 120 180}
+        village_gold=5
         team_name=orcs
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
@@ -136,8 +136,7 @@ Call the Hunt."
         controller=ai
         defeat_condition=no_units_left
         recruit=Goblin Spearman, Orcish Archer, Orcish Assassin, Orcish Grunt, Wolf Rider
-        {GOLD 45 60 75}
-        {INCOME 0 2 4}
+        {GOLD 30 60 90}
         team_name=orcs
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
@@ -158,8 +157,8 @@ Call the Hunt."
         controller=ai
         defeat_condition=no_units_left
         recruit=Goblin Spearman, Orcish Archer, Orcish Assassin, Orcish Grunt, Wolf Rider
-        {GOLD 45 60 75}
-        {INCOME 4 8 12}
+        {GOLD 30 60 90}
+        village_gold=5
         team_name=orcs
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
@@ -180,8 +179,7 @@ Call the Hunt."
         controller=ai
         defeat_condition=no_units_left
         recruit=Goblin Spearman, Orcish Archer, Orcish Assassin, Orcish Grunt, Wolf Rider
-        {GOLD 45 60 75}
-        {INCOME 0 2 4}
+        {GOLD 30 60 90}
         team_name=orcs
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
@@ -212,7 +210,6 @@ Call the Hunt."
             ai_algorithm=experimental_ai
             aggression=0.75
             leader_aggression=1.0
-            ## leader_ignores_keep=yes
             [leader_goal]
                 x,y=22,10
                 auto_remove=yes
@@ -406,6 +403,11 @@ Mostly."
         [filter]
             id=Orc Ship
         [/filter]
+        [filter_condition]
+            [have_unit]
+                id=Viragar
+            [/have_unit]
+        [/filter_condition]
         [message]
             speaker=Viragar
             message= _ "I told you to keep those wyrms from our ship, you useless SCUM! Wyrms breathe fire... ships are wood... fire is BAD for wood."

--- a/scenarios/04_Islands.cfg
+++ b/scenarios/04_Islands.cfg
@@ -62,8 +62,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Merman Fighter, Merman Hunter, Mermaid Initiate
-        {GOLD 120 160 200}
-        {INCOME 4 6 8}
+        {GOLD 80 160 240}
+        {INCOME 3 6 9}
         team_name=merfolk
         user_team_name= _ "Merfolk"
         [leader]
@@ -84,8 +84,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Naga Fighter
-        {GOLD 100 140 180}
-        {INCOME 10 14 18}
+        {GOLD 70 140 210}
+        {INCOME 7 14 21}
         team_name=nagas
         user_team_name= _ "Nagas"
         [leader]
@@ -107,8 +107,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Merman Fighter, Merman Hunter, Mermaid Initiate
-        {GOLD 120 160 200}
-        {INCOME 10 14 18}
+        {GOLD 80 160 240}
+        {INCOME 7 14 21}
         team_name=merfolk
         user_team_name= _ "Merfolk"
         [leader]

--- a/scenarios/10_Fire_Meets_Steel.cfg
+++ b/scenarios/10_Fire_Meets_Steel.cfg
@@ -65,8 +65,8 @@
         side=2
         controller=ai
         recruit=Gryphon Rider, Gryphon Master
-        {GOLD 350 450 550}
-        {INCOME 15 22 30}
+        {GOLD 225 450 675}
+        {INCOME 11 22 33}
         team_name=dwarves
         user_team_name= _ "Dwarves"
         {FLAG_VARIANT knalgan}

--- a/scenarios/11_Confrontation.cfg
+++ b/scenarios/11_Confrontation.cfg
@@ -67,8 +67,8 @@
         side=2
         controller=ai
         recruit=Drake Arbiter, Drake Burner, Drake Clasher, Drake Fighter, Drake Flare, Drake Glider, Drake Thrasher, Drake Warrior, Fire Drake, Sky Drake
-        {GOLD 450 550 650}
-        {INCOME 15 20 25}
+        {GOLD 275 550 825}
+        {INCOME 10 20 30}
         team_name=rival
         user_team_name= _ "Drakes"
         {FLAG_VARIANT long}


### PR DESCRIPTION
Give AI enemies income boosts based on their held villages rather than a flat rate income boost. This gives the AI driven units allied with the player a bigger impact on the battle since they are particularly good at village capture

Widen difference between the difficulty settings  to match most scenarios

Fix bug where if ship is destroyed after Viragar is already captured then a random orc responds to a line Viragar does/can not say (as he is in captivity)