### PR TITLE
Tweaks to S03 and S04

### DIFF
--- a/scenarios/03_The_Contention.cfg
+++ b/scenarios/03_The_Contention.cfg
@@ -92,8 +92,8 @@
         side=2
         controller=ai
         recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider
-        {GOLD 100 115 130}
-        {INCOME 0 2 4}
+        {GOLD 60 115 180}
+        {INCOME 1 2 3}
         village_gold=2
         team_name=rival
         user_team_name= _ "Drakes"

--- a/scenarios/04_Islands.cfg
+++ b/scenarios/04_Islands.cfg
@@ -5,7 +5,7 @@
     name= _ "Islands"
     next_scenario=05_The_Three_Sisters
     {WOV_MAP 04_Islands.map} # TRoW Rough Landing map, unchanged.
-    {TURNS 22 20 18}
+    {TURNS 24 24 24}
     {SUMMER_SCHEDULE_DUSK}
     carryover_percentage=40
     carryover_add=yes


### PR DESCRIPTION
S03: Most scenarios use a 1:2:3 gold and income ratio for enemy forces to differentiate the easy, medium and hard difficulty settings (respectively).

S04: [As suggested in the campaign design howto:](http://catb.org/~esr/wesnoth/campaign-design-howto.html#_races_against_time) avoid turn limits as a difficulty control in ordinary scenarios (they are generally only a carryover control mechanism)